### PR TITLE
fix(RDM-6|RDM-7): Fixing authentication, final with variables renamed

### DIFF
--- a/src/main/java/teampixl/com/pixlpos/constructs/Users.java
+++ b/src/main/java/teampixl/com/pixlpos/constructs/Users.java
@@ -43,11 +43,11 @@ public class Users implements IDataManager {
         - additional_info: null
     ============================================================================================================================================================*/
 
-    public Users(String username, String plainPassword, String email, UserRole role) {
+    public Users(String username, String hashedPassword, String email, UserRole role) {
         if (username == null || username.isEmpty()) {
             throw new IllegalArgumentException("username cannot be null or empty");
         }
-        if (plainPassword == null || plainPassword.isEmpty()) {
+        if (hashedPassword == null || hashedPassword.isEmpty()) {
             throw new IllegalArgumentException("password cannot be null or empty");
         }
         if (role == null) {
@@ -66,7 +66,7 @@ public class Users implements IDataManager {
 
         // Data
         this.data = new HashMap<>();
-        this.data.put("password", PasswordUtils.hashPassword(plainPassword));
+        this.data.put("password", hashedPassword);
         this.data.put("email", email);
         this.data.put("additional_info", null);
     }


### PR DESCRIPTION
Problem was password was being hashed once when creating the user in RegistrationService.java registerUser();, and then again in the creating user construct. Hashing in user construct was removed just leaving the registration service hashing, fixing the issue.